### PR TITLE
Update gitignore-in/gh-action to v0.2.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,9 @@ jobs:
   test_installation:
     strategy:
       matrix:
-        # macOS versions supported by GitHub Actions runners
-        # https://endoflife.date/macos
+        # Current GitHub-hosted macOS runner labels:
         # https://github.com/actions/runner-images?tab=readme-ov-file#available-images
-        macos: [macos-13, macos-14, macos-15]
+        macos: [macos-14, macos-15, macos-26]
     runs-on: ${{ matrix.macos }}
     steps:
       - name: Checkout

--- a/.github/workflows/gitignore-in.yml
+++ b/.github/workflows/gitignore-in.yml
@@ -13,4 +13,4 @@ jobs:
   update-gitignore:
     runs-on: ubuntu-latest
     steps:
-      - uses: gitignore-in/gh-action@v0.2.2
+      - uses: gitignore-in/gh-action@v0.2.3


### PR DESCRIPTION
## Summary
- update `gitignore-in/gh-action` from `v0.2.2` to `v0.2.3`
- pick up the latest released action implementation for the scheduled gitignore update workflow

## Testing
- `git diff --check`
