### PR TITLE
Harden CI workflow token boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,15 @@ name: test macOS installation
 on:
   - pull_request
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Install ShellCheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck
@@ -24,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.macos }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Set up Homebrew
         run: |


### PR DESCRIPTION
## Summary
- Declare the CI workflow token permissions as read-only contents access.
- Pin both checkout steps to the currently resolved actions/checkout v6 commit SHA.

## Validation
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "yaml ok"'
- actionlint .github/workflows/ci.yml
- shellcheck generate.sh
