### PR TITLE
Add a Homebrew formula test block

### DIFF
--- a/myip.rb
+++ b/myip.rb
@@ -16,4 +16,8 @@ class Myip < Formula
   def install
     bin.install "myip" => "myip"
   end
+
+  test do
+    system bin/"myip", "--help"
+  end
 end


### PR DESCRIPTION
## Summary
- add a Homebrew `test do` block for the `myip` formula
- verify the installed `myip` executable responds to `--help`

## Validation
- `ruby -c myip.rb`
- `shellcheck generate.sh`
- `git diff --check`
