### PR TITLE
Fail on empty release archive downloads

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -5,9 +5,31 @@ version="$(curl -fsSL https://api.github.com/repos/kitsuyui/myip/releases/latest
 homepage='https://github.com/kitsuyui/myip'
 
 gethash() {
-  curl -fsSL "${homepage}/releases/download/${version}/$1" 2>/dev/null \
-  | shasum -a 256 \
-  | awk '{print $1}'
+  local file="$1"
+  local tmpfile
+  local checksum
+
+  tmpfile="$(mktemp)"
+  if ! curl -fsSL "${homepage}/releases/download/${version}/${file}" -o "$tmpfile"; then
+    rm -f "$tmpfile"
+    echo "failed to download release archive: ${file}" >&2
+    return 1
+  fi
+
+  if [[ ! -s "$tmpfile" ]]; then
+    rm -f "$tmpfile"
+    echo "release archive is empty: ${file}" >&2
+    return 1
+  fi
+
+  if ! checksum="$(shasum -a 256 "$tmpfile" | awk '{print $1}')"; then
+    rm -f "$tmpfile"
+    echo "failed to calculate checksum: ${file}" >&2
+    return 1
+  fi
+
+  rm -f "$tmpfile"
+  printf '%s\n' "$checksum"
 }
 
 arm64_file=myip_Darwin_arm64.tar.gz


### PR DESCRIPTION
## Summary
- download release archives to a temporary file before calculating their SHA256
- fail when curl cannot download an archive or the downloaded archive is empty
- keep the generated formula unchanged in this PR

## Validation
- `shellcheck generate.sh`
- `bash -n generate.sh`
- `git diff --check`
- mocked curl failure returns `failed to download release archive: myip_Darwin_arm64.tar.gz`
- mocked empty archive returns `release archive is empty: myip_Darwin_arm64.tar.gz`
