### PR TITLE
Add explicit timeout flags to curl calls in generate.sh

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-version="$(curl -fsSL https://api.github.com/repos/kitsuyui/myip/releases/latest | jq -er .tag_name)"
+version="$(curl -fsSL --connect-timeout 30 --max-time 60 https://api.github.com/repos/kitsuyui/myip/releases/latest | jq -er .tag_name)"
 if ! [[ "${version}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+[a-zA-Z0-9.+_-]*$ ]]; then
   echo "unexpected version tag: '${version}'" >&2
   exit 1


### PR DESCRIPTION
## Summary

- Added `--connect-timeout 30` and `--max-time 60` to the GitHub API curl call that fetches the latest release tag.
- Added `--connect-timeout 30` and `--max-time 120` to the `gethash` curl calls that download release assets for checksum computation. The higher `--max-time` for asset downloads accounts for potentially larger file sizes.

Without these flags, `generate.sh` could hang indefinitely if the GitHub API or release asset endpoints become unresponsive, blocking CI or local formula-update runs with no feedback.

## Validation

- Run `./generate.sh` in a normal network environment and confirm `myip.rb` is regenerated correctly.
- Simulate a slow/unreachable endpoint (e.g., via `tc` or a proxy) and confirm the script exits within the configured timeout window rather than hanging.
