### PR TITLE
Validate version tag format before embedding in Ruby formula

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -2,6 +2,10 @@
 set -euo pipefail
 
 version="$(curl -fsSL https://api.github.com/repos/kitsuyui/myip/releases/latest | jq -er .tag_name)"
+if ! [[ "${version}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+[a-zA-Z0-9.+_-]*$ ]]; then
+  echo "unexpected version tag: '${version}'" >&2
+  exit 1
+fi
 homepage='https://github.com/kitsuyui/myip'
 
 gethash() {


### PR DESCRIPTION
## Summary

`generate.sh` fetches the version tag from the GitHub API and embeds it
directly into a Ruby heredoc without validation. If a tag contained `"` or
`\`, the generated `myip.rb` would have a Ruby syntax error and
`brew install myip` would fail.

This PR adds an allowlist regex guard immediately after the API call:

```
if ! [[ "${version}" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+[a-zA-Z0-9.+_-]*$ ]]; then
  echo "unexpected version tag: '${version}'" >&2
  exit 1
fi
```

Any tag that contains `"`, `\`, `$`, spaces, or control characters is
rejected with a non-zero exit before any file is written.

## Validation

- `shellcheck generate.sh` — passes
- The guard is placed before `mktemp`/heredoc, so no partial file is left
  on validation failure

## Notes

Standard semver tags (e.g. `v0.3.10`, `v1.0.0-rc.1`, `v2.0.0+build.1`)
pass the regex. The assumption is that GitHub tag naming conventions make
these characters unlikely in practice; the guard makes that assumption
explicit and enforces it.
