### PR TITLE
Clarify unsupported macOS architectures

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ $ brew tap kitsuyui/homebrew-myip
 $ brew install myip
 ```
 
+## Supported platforms
+
+This formula installs prebuilt macOS binaries for Apple Silicon and 64-bit Intel Macs.
+Other architectures are not supported by the binary formula.
+
 ## Update
 
 ```console

--- a/generate.sh
+++ b/generate.sh
@@ -68,6 +68,8 @@ class Myip < Formula
   elsif Hardware::CPU.intel? and Hardware::CPU.is_64_bit?
     url "https://github.com/kitsuyui/myip/releases/download/${version}/${amd64_file}"
     sha256 "${sha256_amd64}"
+  else
+    odie "myip binary releases are only available for Apple Silicon and 64-bit Intel macOS"
   end
 
   def install

--- a/myip.rb
+++ b/myip.rb
@@ -11,6 +11,8 @@ class Myip < Formula
   elsif Hardware::CPU.intel? and Hardware::CPU.is_64_bit?
     url "https://github.com/kitsuyui/myip/releases/download/v0.3.10/myip_Darwin_x86_64.tar.gz"
     sha256 "30d8a30d0414e7077ef11d6d303239e3512473e3f6d73b22ecfcf3daa501bb01"
+  else
+    odie "myip binary releases are only available for Apple Silicon and 64-bit Intel macOS"
   end
 
   def install


### PR DESCRIPTION
## Summary
- Make unsupported CPU architectures fail with an explicit Homebrew error.
- Keep the generated formula template aligned with the committed formula.
- Document that the binary formula supports Apple Silicon and 64-bit Intel macOS.

## Validation
- `bash -n generate.sh`
- `ruby -c myip.rb`
- `shellcheck generate.sh`
- `actionlint .github/workflows/*.yml`
- `git diff --check`
- `brew ruby` formula load on the current arm64 CPU and a mocked x86_64 CPU
- `brew ruby` with a mocked unsupported CPU exits with the explicit `odie` message
