### PR TITLE
Support HEAD installs from source

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -59,21 +59,32 @@ require "formula"
 
 class Myip < Formula
   homepage "${homepage}"
-  head "${homepage}.git"
-  version "${version}"
 
-  if Hardware::CPU.arm? and Hardware::CPU.is_64_bit?
-    url "https://github.com/kitsuyui/myip/releases/download/${version}/${arm64_file}"
-    sha256 "${sha256_arm64}"
-  elsif Hardware::CPU.intel? and Hardware::CPU.is_64_bit?
-    url "https://github.com/kitsuyui/myip/releases/download/${version}/${amd64_file}"
-    sha256 "${sha256_amd64}"
-  else
-    odie "myip binary releases are only available for Apple Silicon and 64-bit Intel macOS"
+  stable do
+    version "${version}"
+
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      url "https://github.com/kitsuyui/myip/releases/download/${version}/${arm64_file}"
+      sha256 "${sha256_arm64}"
+    elsif Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
+      url "https://github.com/kitsuyui/myip/releases/download/${version}/${amd64_file}"
+      sha256 "${sha256_amd64}"
+    else
+      odie "myip binary releases are only available for Apple Silicon and 64-bit Intel macOS"
+    end
+  end
+
+  head do
+    url "${homepage}.git", branch: "main"
+    depends_on "go" => :build
   end
 
   def install
-    bin.install "myip" => "myip"
+    if build.head?
+      system "go", "build", "-trimpath", "-ldflags", "-s -w", "-o", bin/"myip", "./cmd"
+    else
+      bin.install "myip" => "myip"
+    end
   end
 end
 EOF

--- a/myip.rb
+++ b/myip.rb
@@ -2,21 +2,32 @@ require "formula"
 
 class Myip < Formula
   homepage "https://github.com/kitsuyui/myip"
-  head "https://github.com/kitsuyui/myip.git"
-  version "v0.3.10"
 
-  if Hardware::CPU.arm? and Hardware::CPU.is_64_bit?
-    url "https://github.com/kitsuyui/myip/releases/download/v0.3.10/myip_Darwin_arm64.tar.gz"
-    sha256 "9f849345ff0fae25f2deb429597db065435fb788c82acf14de3a4930786d83ec"
-  elsif Hardware::CPU.intel? and Hardware::CPU.is_64_bit?
-    url "https://github.com/kitsuyui/myip/releases/download/v0.3.10/myip_Darwin_x86_64.tar.gz"
-    sha256 "30d8a30d0414e7077ef11d6d303239e3512473e3f6d73b22ecfcf3daa501bb01"
-  else
-    odie "myip binary releases are only available for Apple Silicon and 64-bit Intel macOS"
+  stable do
+    version "v0.3.10"
+
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      url "https://github.com/kitsuyui/myip/releases/download/v0.3.10/myip_Darwin_arm64.tar.gz"
+      sha256 "9f849345ff0fae25f2deb429597db065435fb788c82acf14de3a4930786d83ec"
+    elsif Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
+      url "https://github.com/kitsuyui/myip/releases/download/v0.3.10/myip_Darwin_x86_64.tar.gz"
+      sha256 "30d8a30d0414e7077ef11d6d303239e3512473e3f6d73b22ecfcf3daa501bb01"
+    else
+      odie "myip binary releases are only available for Apple Silicon and 64-bit Intel macOS"
+    end
+  end
+
+  head do
+    url "https://github.com/kitsuyui/myip.git", branch: "main"
+    depends_on "go" => :build
   end
 
   def install
-    bin.install "myip" => "myip"
+    if build.head?
+      system "go", "build", "-trimpath", "-ldflags", "-s -w", "-o", bin/"myip", "./cmd"
+    else
+      bin.install "myip" => "myip"
+    end
   end
 
   test do


### PR DESCRIPTION
## Summary
- Split the formula into stable and HEAD specs so stable installs keep using the prebuilt macOS archives.
- Add Go as a HEAD-only build dependency and build the CLI from source for `--HEAD` installs.
- Update the formula generator template so future release bumps preserve the HEAD install path.

## Validation
- `shellcheck generate.sh`
- `git diff --check origin/main`
- Temporary tap dry-runs for stable and `--HEAD --build-from-source` installs
- Source build smoke test with `go build -trimpath -ldflags "-s -w" -o <tmp> ./cmd` and `<tmp> --help`