### PR TITLE
chore: add lefthook to run CI checks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,20 @@ Other architectures are not supported by the binary formula.
 $ ./generate.sh
 ```
 
+## Development
+
+Install [lefthook](https://github.com/evilmartians/lefthook) and register the Git hooks:
+
+```console
+$ lefthook install
+```
+
+This sets up the following local hooks:
+
+- **pre-commit / pre-push**: runs `shellcheck generate.sh` to catch shell script issues before committing or pushing.
+
+> **Note:** CI also runs a full Homebrew install test on macOS runners, which is not mirrored locally because it requires a macOS environment with Homebrew.
+
 ## License
 
 [BSD 2-clause "Simplified" License](https://spdx.org/licenses/BSD-2-Clause)

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,13 @@
+pre-commit:
+  commands:
+    shellcheck:
+      run: >
+        for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done;
+        shellcheck generate.sh
+
+pre-push:
+  commands:
+    shellcheck:
+      run: >
+        for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done;
+        shellcheck generate.sh


### PR DESCRIPTION
## Summary

- Add `lefthook.yml` to run `shellcheck generate.sh` as pre-commit and pre-push hooks, mirroring the shellcheck step in CI.
- Add a `## Development` section to `README.md` explaining how to install lefthook and what the hooks do, with a note that the Homebrew install test runs only in CI.

## What is not mirrored locally

The Homebrew install test (`brew install myip`) requires a macOS environment with Homebrew and is macOS-specific. It is intentionally left in CI only.

## Test plan

- [ ] `lefthook install` completes without errors.
- [ ] `shellcheck generate.sh` passes (verified before this PR).
- [ ] pre-commit hook runs shellcheck on commit.
- [ ] pre-push hook runs shellcheck on push.
- [ ] CI shellcheck job continues to pass (no changes to CI or scripts).
