### PR TITLE
ci: add weekly schedule to periodically verify formula installability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: test macOS installation
 on:
-  - pull_request
+  pull_request:
+  schedule:
+    # weekly on Wednesday at 00:00 UTC — installability check independent of upstream releases
+    - cron: '0 0 * * 3'
 
 permissions:
   contents: read
@@ -38,7 +41,7 @@ jobs:
           INSTALLED_PATH="$(brew --repo kitsuyui/myip)"
           cd "$INSTALLED_PATH"
           git checkout "$BRANCH"
-        if: ${{ github.head_ref != 'main' }}
+        if: ${{ github.event_name == 'pull_request' && github.head_ref != 'main' }}
         env:
           BRANCH: ${{ github.head_ref }}
 


### PR DESCRIPTION
The CI workflow (`ci.yml`) only ran on `pull_request` events. When the upstream `myip` release is unchanged, the weekly `update.yml` workflow does not open a PR, so `ci.yml` never runs — leaving the formula's installability unverified for weeks at a time.

This change adds a weekly `schedule` trigger (Wednesday 00:00 UTC) so `brew install myip` is tested independently of upstream release activity.

Two adjustments were made:

1. **Trigger**: added `schedule: - cron: '0 0 * * 3'` alongside `pull_request`.
2. **Condition fix**: the "Checkout branch" step previously used `github.head_ref != 'main'`. On a scheduled run `github.head_ref` is empty, which would cause `git checkout ""` to fail. The condition is tightened to `github.event_name == 'pull_request' && github.head_ref != 'main'` so the step is skipped on schedule runs.
