### PR TITLE
fix: remove deprecated formula require

### DIFF
--- a/generate.sh
+++ b/generate.sh
@@ -67,8 +67,6 @@ sha256_amd64_literal="$(ruby_literal "$sha256_amd64")"
 cd "${0%/*}"
 tmpfile="$(mktemp myip.rb.XXXXXX)"
 cat <<EOF > "$tmpfile"
-require "formula"
-
 class Myip < Formula
   homepage ${homepage_literal}
 

--- a/myip.rb
+++ b/myip.rb
@@ -1,5 +1,3 @@
-require "formula"
-
 class Myip < Formula
   homepage "https://github.com/kitsuyui/myip"
 


### PR DESCRIPTION
## Summary
- Remove the deprecated `require "formula"` line from the checked-in Homebrew formula.
- Update the formula generator so future generated formulae keep the same modern Homebrew shape.

## Validation
- `shellcheck generate.sh`
- `actionlint .github/workflows/*.yml`
- `ruby -c myip.rb`
- `bash -n generate.sh`
- `git diff --check origin/main...HEAD`
- collateral check: clean

## Note
- `brew audit` and `brew style` could not be reproduced against the branch checkout because current Homebrew rejects path formulae outside an installed tap. The pull request CI macOS install job is the remote gate for formula behavior.
