### PR TITLE
Ignore generate.sh temporary formula files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,7 @@ Backups.backupdb
 .MobileBackups.trash
 MobileBackups.trash
 tmbootpicker.efi
+# -----------------------------------------------------------------------------
+# generate.sh can leave this root temp file behind if it exits before mv.
+# -----------------------------------------------------------------------------
+myip.rb.??????

--- a/.gitignore.in
+++ b/.gitignore.in
@@ -1,3 +1,6 @@
 gibo dump Linux
 gibo dump Windows
 gibo dump macOS
+
+echo '# generate.sh can leave this root temp file behind if it exits before mv.'
+echo 'myip.rb.??????'


### PR DESCRIPTION
## Summary

- Add the `generate.sh` root temporary formula file pattern to `.gitignore.in`.
- Regenerate `.gitignore` with `gitignore.in` so failed generator runs no longer leave `myip.rb.XXXXXX` files as untracked noise.

## Validation

- `gitignore.in`
- `actionlint .github/workflows/*.yml`
- `shellcheck generate.sh`
- `bash -n generate.sh`
- `ruby -c myip.rb`
- `git diff --check`
- `git check-ignore` against a generated `myip.rb.XXXXXX` temp file
- collateral check: clean
