### PR TITLE
ci: propose dropping deprecated macos-14 from install matrix

### DIFF
--- a/docs/ci/drop-deprecated-macos-14-runner.patch
+++ b/docs/ci/drop-deprecated-macos-14-runner.patch
@@ -1,0 +1,15 @@
+diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
+index 342f563..9937e08 100644
+--- a/.github/workflows/ci.yml
++++ b/.github/workflows/ci.yml
+@@ -26,7 +26,9 @@ jobs:
+       matrix:
+         # Current GitHub-hosted macOS runner labels:
+         # https://github.com/actions/runner-images?tab=readme-ov-file#available-images
+-        macos: [macos-14, macos-15, macos-26]
++        # macos-14 is deprecated (retiring 2026-11-02):
++        # https://github.com/actions/runner-images/issues/13518
++        macos: [macos-15, macos-26]
+     runs-on: ${{ matrix.macos }}
+     steps:
+       - name: Checkout


### PR DESCRIPTION
## Why

GitHub Actions has begun deprecating the `macos-14` / `macos-14-arm64` runner images (deprecation started 2026-07-06, brownout failures starting October, full retirement 2026-11-02 — see [actions/runner-images#13518](https://github.com/actions/runner-images/issues/13518)). Keeping `macos-14` in the `test_installation` matrix risks scheduled/PR job failures once the brownout period begins.

This addresses `ci-operations-audit-004`. That finding worried that `macos-26` was an unavailable/future runner label, but investigation shows the opposite: the latest weekly scheduled run ([run 30415305351](https://github.com/kitsuyui/homebrew-myip/actions/runs/30415305351), 2026-07-29) passed `test_installation` on `macos-14`, `macos-15`, **and** `macos-26` alike. `macos-26` is a currently valid, passing GitHub-hosted runner and should stay. `macos-14` is the actual, evidenced deprecation risk.

## What

Drops `macos-14` from the `test_installation` matrix, keeping `macos-15` and `macos-26` — both currently supported and both green on the latest run.

## Why a patch file instead of a direct edit

The automation account opening this PR holds a GitHub token without the `workflow` OAuth scope. Pushing a branch that directly modifies `.github/workflows/ci.yml` is rejected by GitHub ("refusing to allow an OAuth App to create or update workflow ... without `workflow` scope"). The intended diff is included as `docs/ci/drop-deprecated-macos-14-runner.patch`. A maintainer with `workflow` scope can land it with:

```console
$ git apply docs/ci/drop-deprecated-macos-14-runner.patch
$ git add .github/workflows/ci.yml
$ git rm docs/ci/drop-deprecated-macos-14-runner.patch
$ git commit
```

## Verification

- `git apply --check docs/ci/drop-deprecated-macos-14-runner.patch` applies cleanly against current `.github/workflows/ci.yml`.
- `shellcheck generate.sh` passes (unaffected by this change, but re-run as the repo's only local quality gate).
- Manually confirmed via `gh run view 30415305351` that all three `test_installation` matrix jobs (macos-14, macos-15, macos-26) succeeded on the latest scheduled run prior to this change.
- This PR is left open; it is not merged as part of this automation run.